### PR TITLE
Update memcpy to reflect prefix size change

### DIFF
--- a/userspace/libpman/src/maps.c
+++ b/userspace/libpman/src/maps.c
@@ -354,7 +354,7 @@ static int init_filters()
 		struct filter_map_entry filter_entry = {};
 		filter_entry.arg_num = g_state.filters[i].entry.arg_num;
 		filter_entry.num_prefixes = g_state.filters[i].entry.num_prefixes;
-		memcpy(&filter_entry.prefixes, &g_state.filters[i].entry.prefixes, sizeof(u_int8_t) * 32 * 32);
+		memcpy(&filter_entry.prefixes, &g_state.filters[i].entry.prefixes, sizeof(u_int8_t) * 12 * 32);
 		if (bpf_map_update_elem(filter_maps_fd, &g_state.filters[i].syscall, &filter_entry, BPF_ANY) != 0) 
 		{
 			pman_print_error("failed to insert into filters map");


### PR DESCRIPTION
Forgot to update this reference when adjusting the number of prefixes per filter from 32 to 12
